### PR TITLE
Include the image meta tag for BlogPosting schema when strap images are disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.5
+
+- Include the meta tag for a posts image if strap_image is not used.
+
 ## 4.1.4
 
 - Fixed issues with breadcrumb rich snippets (schema.org)

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -19,6 +19,9 @@ css_package: blog
         {% picture header_image {{image_path}} --alt {{image_alt}} %}
         <meta itemprop="image" content="{{image_path | absolute_url}}" />
     </div>
+    {% else %}
+        {% assign image_path = page.image %}
+        <meta itemprop="image" content="{{image_path | absolute_url}}" />
     {% endif %}
     <div class="row">
         <div class="container">

--- a/_pages/blog.md
+++ b/_pages/blog.md
@@ -15,6 +15,6 @@ flow:
         # category: News
       - format: custom_include
         source: blog/display_latest_posts.html
-        limit: 4
+        limit: 20
         category: blog
 ---

--- a/_posts/2020-03-23-getting-started-with-the-jumbo-jekyll copy 7.md
+++ b/_posts/2020-03-23-getting-started-with-the-jumbo-jekyll copy 7.md
@@ -7,6 +7,7 @@ image: /assets/images/breadcrumb-image.jpg
 author: kyle
 category: blog
 tags: jekyll note theme jumbo-jekyll-theme
+strap_image: false
 ---
 
 # Introduction

--- a/linaro-jekyll-theme.gemspec
+++ b/linaro-jekyll-theme.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "linaro-jekyll-theme"
-  spec.version       = "4.1.4"
+  spec.version       = "4.1.5"
   spec.authors       = ["Kyle Kirkby"]
   spec.email         = ["kyle.kirkby@linaro.org"]
 


### PR DESCRIPTION
Minor version update to include the image meta tag for BlogPosting schema when strap images are disabled