### PR TITLE
Added custom_include for feature blocks (4.1.6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 !package.json
 !gulpfile.js
 !mkdocs.yml
+!requirements.txt
 # Now whitelist the desired folders
 !_includes
 !_data

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@
 # Ignore the following files specifically
 assets/resized
 assets/images/test
+_includes/test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,33 +1,78 @@
-## 4.1.5
+# CHANGELOG
+
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Changelog](http://keepachangelog.com/).
+
+## Unreleased
+
+---
+
+### New
+
+### Changes
+
+### Fixes
+
+### Breaks
+
+## 4.1.5 - (2020-11-10)
+
+---
+
+### Changes
 
 - Include the meta tag for a posts image if strap_image is not used.
 
-## 4.1.4
+## 4.1.4 - (2020-11-01)
+
+---
+
+### Changes
 
 - Fixed issues with breadcrumb rich snippets (schema.org)
 - Added WebPage as the base schema type
 - Fixed issues with blocks flow include
 - Fixed issues with the members.html flow include
 
-## 4.1.3
+## 4.1.3 - (2020-11-01)
+
+---
+
+### Changes
 
 - Removed limit on tags from the post.html layout. All tags now display (if enabled) on the post itself.
 - Updated footer brand to better support custom URLs/alt text
 - Updated docs
 
-## 4.1.2
+## 4.1.3 - (2020-11-01)
+
+---
+
+### Changes
 
 - Added ability to toggle post tags output and limit the number of tags visible.
 
-## 4.1.1
+## 4.1.1 - (2020-11-01)
+
+---
+
+### Changes
 
 - Tags bug fix for spaced/accented tags
 
-## 4.1.0
+## 4.1.0 - (2020-11-01)
+
+---
+
+### New
 
 - Added tags support for posts! Can also manage multiple post categories.
 
-## 4.0.2
+## 4.1.0 - (2020-11-01)
+
+---
+
+### Changes
 
 - Fixes issue with jumbotron include that means an empty array still renders a slider.
 - Added truncate filter to featured post description in the display_latest_posts.html include.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Changelog](http://keepachangelog.com/).
 
-## Unreleased
 
+
+## Unreleased
 ---
 
 ### New
@@ -14,6 +15,16 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### Fixes
 
 ### Breaks
+
+
+## 4.1.6 - (2020-11-16)
+---
+
+### Changes
+* Adds custom_include support for feature blocks.
+
+
+---
 
 ## 4.1.5 - (2020-11-10)
 

--- a/_includes/flow/feature_block.html
+++ b/_includes/flow/feature_block.html
@@ -36,6 +36,9 @@
             {% if include.object.feature_block_content.buttons %}
                 {% include flow/buttons.html object=include.object.feature_block_content.buttons %}
             {% endif %}
+            {% if include.object.feature_block_content.custom_include %}
+                {% include {{include.object.feature_block_content.custom_include}} object=include.object %}
+            {% endif %}
         </div>
     </div>
 </div>

--- a/_pages/flow.md
+++ b/_pages/flow.md
@@ -364,6 +364,7 @@ flow:
             url: https://www.youtube.com/watch?v=QH2-TGUlwu4
             poster_image: /assets/images/breadcrumb-image.jpg
           title: Feature Block
+          custom_include: test/feature_block.html
           text: >
             A feature block with a youtube video.
           buttons:
@@ -379,9 +380,10 @@ flow:
           position: "right"
           type: "image"
           image_content_path: /assets/images/breadcrumb-image.jpg
-          title: Feature Block
+          title: Feature Block 2
           text: >
             A feature block with an image.
+          custom_include: test/feature_block.html
           buttons:
             - title: Button 1
               url: /about/

--- a/docs/layouts/flow.md
+++ b/docs/layouts/flow.md
@@ -364,6 +364,8 @@ sections:
       # Optional - specify an image to be used as featured content
       # type: "image"
       # image_content_path: /assets/images/content/background-image1.jpg
+      # Add a custom Jekyll include to the end of your feature block's content.
+      custom_include: test/test_feature_block.html 
       # Optional - add an images slider to be used as featured content
       type: "slider"
       # Slider content - see the slider section details for more information on adding slider's

--- a/linaro-jekyll-theme.gemspec
+++ b/linaro-jekyll-theme.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "linaro-jekyll-theme"
-  spec.version       = "4.1.5"
+  spec.version       = "4.1.6"
   spec.authors       = ["Kyle Kirkby"]
   spec.email         = ["kyle.kirkby@linaro.org"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,17 @@
+changelog-cli==0.7.1
+click==7.1.2
+future==0.18.2
+Jinja2==2.11.2
+joblib==0.17.0
+livereload==2.6.3
+lunr==0.5.8
+Markdown==3.3.2
+MarkupSafe==1.1.1
+mkdocs==1.1.2
+nltk==3.5
+pkg-resources==0.0.0
+PyYAML==5.3.1
+regex==2020.10.23
+six==1.15.0
+tornado==6.0.4
+tqdm==4.50.2


### PR DESCRIPTION
Added custom_include for feature blocks. The new Developer Services pages require dynamic services collection items to be rendered on a per-feature_block basis.